### PR TITLE
[Experiment] Integrate error-stack for better error and stacktrace reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +166,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "clap_derive",
+ "error-stack",
  "glob-match",
  "itertools",
  "jwalk",
@@ -169,6 +176,7 @@ dependencies = [
  "rusty-hook",
  "serde",
  "serde_yaml",
+ "thiserror",
  "tracing",
  "tracing-subscriber",
 ]
@@ -302,6 +310,16 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "error-stack"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f00447f331c7f726db5b8532ebc9163519eed03c6d7c8b73c90b3ff5646ac85"
+dependencies = [
+ "anyhow",
+ "rustc_version",
 ]
 
 [[package]]
@@ -606,6 +624,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,6 +669,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
@@ -724,6 +757,26 @@ name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
+name = "thiserror"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.11",
+]
 
 [[package]]
 name = "thread_local"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.2.1", features = ["derive"] }
 clap_derive = "4.2.0"
+error-stack = "0.3.1"
 glob-match = "0.2.1"
 itertools = "0.10.5"
 jwalk = "0.8.1"
@@ -14,6 +15,7 @@ rayon = "1.7.0"
 regex = "1.7.3"
 serde = { version = "1.0.159", features = ["derive"] }
 serde_yaml = "0.9.19"
+thiserror = "1.0.40"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 

--- a/src/ownership.rs
+++ b/src/ownership.rs
@@ -10,6 +10,7 @@ mod tests;
 
 use crate::project::Project;
 
+use error_stack::Result;
 pub use validator::Errors as ValidationErrors;
 
 use self::{

--- a/src/ownership/validator.rs
+++ b/src/ownership/validator.rs
@@ -23,6 +23,8 @@ pub struct Validator {
     pub file_generator: FileGenerator,
 }
 
+use error_stack::{Context, Report, Result};
+
 #[derive(Debug)]
 struct Owner {
     pub sources: Vec<String>,
@@ -53,7 +55,7 @@ impl Validator {
         if validation_errors.is_empty() {
             Ok(())
         } else {
-            Err(Errors(validation_errors))
+            Err(Report::new(Errors(validation_errors)))
         }
     }
 
@@ -190,8 +192,4 @@ impl Display for Errors {
     }
 }
 
-impl std::error::Error for Errors {
-    fn description(&self) -> &str {
-        "Error"
-    }
-}
+impl Context for Errors {}


### PR DESCRIPTION
[error-stack](https://hash.dev/blog/announcing-error-stack) is a fairly recent Rust error reporting library meant to build richer and more concise error reports. Using it adds boilerplate and forces explicit error types across all fallible methods. The result is a much more concise and clear terminal output when something goes wrong.

For example:
<img width="870" alt="image" src="https://user-images.githubusercontent.com/653256/229308111-28957fe5-9ea0-41c0-847c-d37df9598071.png">

Or:
<img width="1063" alt="image" src="https://user-images.githubusercontent.com/653256/229308123-27939b39-ca46-40da-9452-261b8956c89a.png">

I'm not yet sure the boilerplate is worth it, [color-eyre](https://github.com/yaahc/color-eyre/), an older error reporting library might be a better fit. It would allow for good enough error traces, without being forced to define error types for every layer in the stack. (Here's an [alternative](https://github.com/rubyatscale/codeowners-rs/pull/3) using color-eyre).