### PR TITLE
Fix GitHub capitalization, link to docs about CODEOWNERS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Codeowners
-This is a CLI tool to generate Github's `CODEOWNERS` file from an existing project assuming certain conventions around file annotations and Ruby/Javascript packages.
+This is a CLI tool to generate [GitHub `CODEOWNERS` files](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) from an existing project assuming certain conventions around file annotations and Ruby/Javascript packages.
 It's also the [oxidation](https://wiki.mozilla.org/Oxidation) of an existing [CLI tool](https://github.com/rubyatscale/code_ownership) written in Ruby.
 
 `CODEOWNERS` generation happens as part of our git commit hooks and on Gusto's main repo takes ~18s to run. The Rust implementation which is a drop in replacement cuts that down to <= 2s. (Tested on a Mackbook M1)


### PR DESCRIPTION
Just a pet peeve 😅  Also, link to docs about codeowners