### PR TITLE
Bumping crates and addressing dead code warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ dependencies = [
  "error-stack",
  "glob-match",
  "ignore",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "path-clean",
  "predicates",
  "pretty_assertions",
@@ -307,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "error-stack"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27a72baa257b5e0e2de241967bc5ee8f855d6072351042688621081d66b2a76b"
+checksum = "fe413319145d1063f080f27556fd30b1d70b01e2ba10c2a6e40d4be982ffc5d1"
 dependencies = [
  "anyhow",
  "rustc_version",
@@ -452,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ debug = true
 [dependencies]
 clap = { version = "4.2.1", features = ["derive"] }
 clap_derive = "4.2.0"
-error-stack = "0.4.1"
+error-stack = "0.5.0"
 glob-match = "0.2.1"
 ignore = "0.4.20"
-itertools = "0.12.1"
+itertools = "0.13.0"
 path-clean = "1.0.1"
 rayon = "1.7.0"
 regex = "1.7.3"

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,7 @@ pub struct Config {
     pub vendored_gems_path: String,
 }
 
+#[allow(dead_code)]
 #[derive(Deserialize, Debug)]
 pub struct RubyPackageConfig {
     #[serde(alias = "pack_paths")]

--- a/src/ownership.rs
+++ b/src/ownership.rs
@@ -22,6 +22,7 @@ pub struct Ownership {
     project: Arc<Project>,
 }
 
+#[allow(dead_code)]
 pub struct Entry {
     pub path: String,
     pub github_team: String,


### PR DESCRIPTION
Keeping the crates current.

Also, rust `1.82.0` is marking some code as unused. Allowing it for now.