### PR TITLE
Adding for-file to the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Commands:
   generate               Generate the CODEOWNERS file and save it to '--codeowners-file-path'
   validate               Validate the validity of the CODEOWNERS file. A validation failure will exit with a failure code and a detailed output of the validation errors
   generate-and-validate  Chains both 'generate' and 'validate' commands
+  for-file               Print the owners for a given file
   help                   Print this message or the help of the given subcommand(s)
 
 Options:

--- a/src/ownership.rs
+++ b/src/ownership.rs
@@ -1,13 +1,16 @@
-use mapper::TeamName;
-use std::sync::Arc;
+use file_owner_finder::FileOwnerFinder;
+use mapper::{OwnerMatcher, TeamName};
+use std::{
+    fmt::{self, Display},
+    path::Path,
+    sync::Arc,
+};
 use tracing::{info, instrument};
 
 mod file_generator;
+mod file_owner_finder;
 mod mapper;
 mod validator;
-
-#[cfg(test)]
-mod tests;
 
 use crate::{ownership::mapper::DirectoryMapper, project::Project};
 
@@ -21,6 +24,26 @@ use self::{
 
 pub struct Ownership {
     project: Arc<Project>,
+}
+
+pub struct FileOwner {
+    pub team_name: TeamName,
+    pub team_config_file_path: String,
+}
+
+impl Display for FileOwner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Team: {}\nTeam YML: {}", self.team_name, self.team_config_file_path)
+    }
+}
+
+impl Default for FileOwner {
+    fn default() -> Self {
+        Self {
+            team_name: "Unowned".to_string(),
+            team_config_file_path: "Unowned".to_string(),
+        }
+    }
 }
 
 #[allow(dead_code)]
@@ -63,6 +86,29 @@ impl Ownership {
     }
 
     #[instrument(level = "debug", skip_all)]
+    pub fn for_file(&self, file_path: &str) -> Result<Vec<FileOwner>, ValidatorErrors> {
+        info!("getting file ownership for {}", file_path);
+        let owner_matchers: Vec<OwnerMatcher> = self.mappers().iter().flat_map(|mapper| mapper.owner_matchers()).collect();
+        let file_owner_finder = FileOwnerFinder {
+            owner_matchers: &owner_matchers,
+        };
+        let owners = file_owner_finder.find(Path::new(file_path));
+        Ok(owners
+            .iter()
+            .map(|owner| match self.project.get_team(&owner.team_name) {
+                Some(team) => FileOwner {
+                    team_name: owner.team_name.clone(),
+                    team_config_file_path: team
+                        .path
+                        .strip_prefix(&self.project.base_path)
+                        .map_or_else(|_| String::new(), |p| p.to_string_lossy().to_string()),
+                },
+                None => FileOwner::default(),
+            })
+            .collect())
+    }
+
+    #[instrument(level = "debug", skip_all)]
     pub fn generate_file(&self) -> String {
         info!("generating codeowners file");
         let file_generator = FileGenerator { mappers: self.mappers() };
@@ -79,5 +125,28 @@ impl Ownership {
             Box::new(TeamYmlMapper::build(self.project.clone())),
             Box::new(TeamGemMapper::build(self.project.clone())),
         ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::common_test::tests::build_ownership_with_all_mappers;
+
+    #[test]
+    fn test_for_file_owner() -> Result<(), Box<dyn std::error::Error>> {
+        let ownership = build_ownership_with_all_mappers()?;
+        let file_owners = ownership.for_file("app/consumers/directory_owned.rb").unwrap();
+        assert_eq!(file_owners.len(), 1);
+        assert_eq!(file_owners[0].team_name, "Bar");
+        assert_eq!(file_owners[0].team_config_file_path, "config/teams/bar.yml");
+        Ok(())
+    }
+
+    #[test]
+    fn test_for_file_no_owner() -> Result<(), Box<dyn std::error::Error>> {
+        let ownership = build_ownership_with_all_mappers()?;
+        let file_owners = ownership.for_file("app/madeup/foo.rb").unwrap();
+        assert_eq!(file_owners.len(), 0);
+        Ok(())
     }
 }

--- a/src/ownership/file_owner_finder.rs
+++ b/src/ownership/file_owner_finder.rs
@@ -1,0 +1,97 @@
+use std::{collections::HashMap, path::Path};
+
+use super::mapper::{directory_mapper::is_directory_mapper_source, OwnerMatcher, Source, TeamName};
+
+#[derive(Debug)]
+pub struct Owner {
+    pub sources: Vec<Source>,
+    pub team_name: TeamName,
+}
+
+pub struct FileOwnerFinder<'a> {
+    pub owner_matchers: &'a [OwnerMatcher],
+}
+
+impl<'a> FileOwnerFinder<'a> {
+    pub fn find(&self, relative_path: &Path) -> Vec<Owner> {
+        let mut team_sources_map: HashMap<&TeamName, Vec<Source>> = HashMap::new();
+        let mut directory_overrider = DirectoryOverrider::default();
+
+        for owner_matcher in self.owner_matchers {
+            let (owner, source) = owner_matcher.owner_for(relative_path);
+
+            if let Some(team_name) = owner {
+                if is_directory_mapper_source(source) {
+                    directory_overrider.process(team_name, source);
+                } else {
+                    team_sources_map.entry(team_name).or_default().push(source.clone());
+                }
+            }
+        }
+
+        // Add most specific directory owner if it exists
+        if let Some((team_name, source)) = directory_overrider.specific_directory_owner() {
+            team_sources_map.entry(team_name).or_default().push(source.clone());
+        }
+
+        team_sources_map
+            .into_iter()
+            .map(|(team_name, sources)| Owner {
+                sources,
+                team_name: team_name.clone(),
+            })
+            .collect()
+    }
+}
+
+/// DirectoryOverrider is used to override the owner of a directory if a more specific directory owner is found.
+#[derive(Debug, Default)]
+pub struct DirectoryOverrider<'a> {
+    specific_directory_owner: Option<(&'a TeamName, &'a Source)>,
+}
+
+impl<'a> DirectoryOverrider<'a> {
+    fn process(&mut self, team_name: &'a TeamName, source: &'a Source) {
+        if self
+            .specific_directory_owner
+            .map_or(true, |(_, current_source)| current_source.len() < source.len())
+        {
+            self.specific_directory_owner = Some((team_name, source));
+        }
+    }
+
+    fn specific_directory_owner(&self) -> Option<(&TeamName, &Source)> {
+        self.specific_directory_owner
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_directory_overrider() {
+        let mut directory_overrider = DirectoryOverrider::default();
+        assert_eq!(directory_overrider.specific_directory_owner(), None);
+        let team_name_1 = "team1".to_string();
+        let source_1 = "src/**".to_string();
+        directory_overrider.process(&team_name_1, &source_1);
+        assert_eq!(directory_overrider.specific_directory_owner(), Some((&team_name_1, &source_1)));
+
+        let team_name_longest = "team2".to_string();
+        let source_longest = "source/subdir/**".to_string();
+        directory_overrider.process(&team_name_longest, &source_longest);
+        assert_eq!(
+            directory_overrider.specific_directory_owner(),
+            Some((&team_name_longest, &source_longest))
+        );
+
+        let team_name_3 = "team3".to_string();
+        let source_3 = "source/**".to_string();
+        directory_overrider.process(&team_name_3, &source_3);
+        assert_eq!(
+            directory_overrider.specific_directory_owner(),
+            Some((&team_name_longest, &source_longest))
+        );
+    }
+}

--- a/src/ownership/mapper.rs
+++ b/src/ownership/mapper.rs
@@ -1,11 +1,10 @@
-use directory_mapper::is_directory_mapper_source;
 use glob_match::glob_match;
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
 };
 
-mod directory_mapper;
+pub(crate) mod directory_mapper;
 mod package_mapper;
 mod team_file_mapper;
 mod team_gem_mapper;
@@ -51,98 +50,9 @@ impl OwnerMatcher {
     }
 }
 
-#[derive(Debug)]
-pub struct Owner {
-    pub sources: Vec<Source>,
-    pub team_name: TeamName,
-}
-
-pub struct FileOwnerFinder<'a> {
-    pub owner_matchers: &'a [OwnerMatcher],
-}
-
-impl<'a> FileOwnerFinder<'a> {
-    pub fn find(&self, relative_path: &Path) -> Vec<Owner> {
-        let mut team_sources_map: HashMap<&TeamName, Vec<Source>> = HashMap::new();
-        let mut directory_overrider = DirectoryOverrider::default();
-
-        for owner_matcher in self.owner_matchers {
-            let (owner, source) = owner_matcher.owner_for(relative_path);
-
-            if let Some(team_name) = owner {
-                if is_directory_mapper_source(source) {
-                    directory_overrider.process(team_name, source);
-                } else {
-                    team_sources_map.entry(team_name).or_default().push(source.clone());
-                }
-            }
-        }
-
-        // Add most specific directory owner if it exists
-        if let Some((team_name, source)) = directory_overrider.specific_directory_owner() {
-            team_sources_map.entry(team_name).or_default().push(source.clone());
-        }
-
-        team_sources_map
-            .into_iter()
-            .map(|(team_name, sources)| Owner {
-                sources,
-                team_name: team_name.clone(),
-            })
-            .collect()
-    }
-}
-
-/// DirectoryOverrider is used to override the owner of a directory if a more specific directory owner is found.
-#[derive(Debug, Default)]
-struct DirectoryOverrider<'a> {
-    specific_directory_owner: Option<(&'a TeamName, &'a Source)>,
-}
-
-impl<'a> DirectoryOverrider<'a> {
-    fn process(&mut self, team_name: &'a TeamName, source: &'a Source) {
-        if self
-            .specific_directory_owner
-            .map_or(true, |(_, current_source)| current_source.len() < source.len())
-        {
-            self.specific_directory_owner = Some((team_name, source));
-        }
-    }
-
-    fn specific_directory_owner(&self) -> Option<(&TeamName, &Source)> {
-        self.specific_directory_owner
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_directory_overrider() {
-        let mut directory_overrider = DirectoryOverrider::default();
-        assert_eq!(directory_overrider.specific_directory_owner(), None);
-        let team_name_1 = "team1".to_string();
-        let source_1 = "src/**".to_string();
-        directory_overrider.process(&team_name_1, &source_1);
-        assert_eq!(directory_overrider.specific_directory_owner(), Some((&team_name_1, &source_1)));
-
-        let team_name_longest = "team2".to_string();
-        let source_longest = "source/subdir/**".to_string();
-        directory_overrider.process(&team_name_longest, &source_longest);
-        assert_eq!(
-            directory_overrider.specific_directory_owner(),
-            Some((&team_name_longest, &source_longest))
-        );
-
-        let team_name_3 = "team3".to_string();
-        let source_3 = "source/**".to_string();
-        directory_overrider.process(&team_name_3, &source_3);
-        assert_eq!(
-            directory_overrider.specific_directory_owner(),
-            Some((&team_name_longest, &source_longest))
-        );
-    }
 
     fn assert_owner_for(glob: &str, relative_path: &str, expect_match: bool) {
         let source = "directory_mapper (\"packs/bam\")".to_string();

--- a/src/ownership/validator.rs
+++ b/src/ownership/validator.rs
@@ -13,8 +13,8 @@ use tracing::debug;
 use tracing::instrument;
 
 use super::file_generator::FileGenerator;
-use super::mapper::FileOwnerFinder;
-use super::mapper::Owner;
+use super::file_owner_finder::FileOwnerFinder;
+use super::file_owner_finder::Owner;
 use super::mapper::{Mapper, OwnerMatcher, TeamName};
 
 pub struct Validator {

--- a/src/project.rs
+++ b/src/project.rs
@@ -267,6 +267,10 @@ impl Project {
             .expect("Could not generate relative path")
     }
 
+    pub fn get_team(&self, name: &str) -> Option<Team> {
+        self.team_by_name().get(name).cloned()
+    }
+
     pub fn team_by_name(&self) -> HashMap<String, Team> {
         let mut result: HashMap<String, Team> = HashMap::new();
 

--- a/tests/fixtures/invalid_project/ruby/app/services/.codeowner
+++ b/tests/fixtures/invalid_project/ruby/app/services/.codeowner
@@ -1,0 +1,1 @@
+Payroll

--- a/tests/fixtures/invalid_project/ruby/app/services/multi_owned.rb
+++ b/tests/fixtures/invalid_project/ruby/app/services/multi_owned.rb
@@ -1,0 +1,1 @@
+# @team Payments

--- a/tests/invalid_project_test.rs
+++ b/tests/invalid_project_test.rs
@@ -17,3 +17,36 @@ fn test_validate() -> Result<(), Box<dyn Error>> {
 
     Ok(())
 }
+
+#[test]
+fn test_for_file() -> Result<(), Box<dyn Error>> {
+    Command::cargo_bin("codeowners")?
+        .arg("--project-root")
+        .arg("tests/fixtures/invalid_project")
+        .arg("for-file")
+        .arg("ruby/app/models/blockchain.rb")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Team: Unowned"))
+        .stdout(predicate::str::contains("Team YML: Unowned"));
+
+    Ok(())
+}
+
+#[test]
+fn test_for_file_multiple_owners() -> Result<(), Box<dyn Error>> {
+    Command::cargo_bin("codeowners")?
+        .arg("--project-root")
+        .arg("tests/fixtures/invalid_project")
+        .arg("for-file")
+        .arg("ruby/app/services/multi_owned.rb")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Error: file is owned by multiple teams!"))
+        .stdout(predicate::str::contains("Team: Payments"))
+        .stdout(predicate::str::contains("Team YML: config/teams/payments.yml"))
+        .stdout(predicate::str::contains("Team: Payroll"))
+        .stdout(predicate::str::contains("Team YML: config/teams/payroll.yml"));
+
+    Ok(())
+}

--- a/tests/valid_project_test.rs
+++ b/tests/valid_project_test.rs
@@ -1,4 +1,5 @@
 use assert_cmd::prelude::*;
+use predicates::prelude::predicate;
 use std::{error::Error, path::Path, process::Command};
 
 #[test]
@@ -28,6 +29,21 @@ fn test_generate() -> Result<(), Box<dyn Error>> {
     let actual_codeowners: String = std::fs::read_to_string(Path::new("tmp/CODEOWNERS"))?;
 
     assert_eq!(expected_codeowners, actual_codeowners);
+
+    Ok(())
+}
+
+#[test]
+fn test_for_file() -> Result<(), Box<dyn Error>> {
+    Command::cargo_bin("codeowners")?
+        .arg("--project-root")
+        .arg("tests/fixtures/valid_project")
+        .arg("for-file")
+        .arg("ruby/app/models/payroll.rb")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Team: Payroll"))
+        .stdout(predicate::str::contains("Team YML: config/teams/payroll.yml"));
 
     Ok(())
 }


### PR DESCRIPTION
Adding `for-file` command that prints the owner of the provided file path argument.
```bash
codeowners for-file <path-to-file>
```
Responds with the team name and path to team config yml