### PR TITLE
Read codeowners on demand

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -114,13 +114,13 @@ fn cli() -> Result<(), Error> {
     let ownership = Ownership::build(Project::build(&project_root, &codeowners_file_path, &config).change_context(Error::Io)?);
 
     match args.command {
-        Command::Validate => ownership.validate(false).change_context(Error::ValidationFailed)?,
+        Command::Validate => ownership.validate().change_context(Error::ValidationFailed)?,
         Command::Generate => {
             std::fs::write(codeowners_file_path, ownership.generate_file()).change_context(Error::Io)?;
         }
         Command::GenerateAndValidate => {
             std::fs::write(codeowners_file_path, ownership.generate_file()).change_context(Error::Io)?;
-            ownership.validate(true).change_context(Error::ValidationFailed)?
+            ownership.validate().change_context(Error::ValidationFailed)?
         }
         Command::ForFile { name } => {
             let file_owners = ownership.for_file(&name).change_context(Error::Io)?;

--- a/src/ownership.rs
+++ b/src/ownership.rs
@@ -86,7 +86,7 @@ impl Ownership {
     }
 
     #[instrument(level = "debug", skip_all)]
-    pub fn validate(&self, skip_codeowners_file_validation: bool) -> Result<(), ValidatorErrors> {
+    pub fn validate(&self) -> Result<(), ValidatorErrors> {
         info!("validating file ownership");
         let validator = Validator {
             project: self.project.clone(),
@@ -94,7 +94,7 @@ impl Ownership {
             file_generator: FileGenerator { mappers: self.mappers() },
         };
 
-        validator.validate(skip_codeowners_file_validation)
+        validator.validate()
     }
 
     #[instrument(level = "debug", skip_all)]

--- a/src/project.rs
+++ b/src/project.rs
@@ -23,7 +23,7 @@ pub struct Project {
     pub packages: Vec<Package>,
     pub vendored_gems: Vec<VendoredGem>,
     pub teams: Vec<Team>,
-    pub codeowners_file: String,
+    pub codeowners_file_path: PathBuf,
     pub directory_codeowner_files: Vec<DirectoryCodeownersFile>,
 }
 
@@ -249,12 +249,6 @@ impl Project {
             "finished scanning project",
         );
 
-        let codeowners_file: String = if codeowners_file_path.exists() {
-            std::fs::read_to_string(codeowners_file_path).change_context(Error::Io)?
-        } else {
-            "".to_owned()
-        };
-
         let owned_files = owned_files(owned_file_paths);
 
         Ok(Project {
@@ -263,9 +257,18 @@ impl Project {
             vendored_gems,
             teams,
             packages,
-            codeowners_file,
+            codeowners_file_path: codeowners_file_path.to_path_buf(),
             directory_codeowner_files,
         })
+    }
+
+    pub fn get_codeowners_file(&self) -> Result<String, Error> {
+        let codeowners_file: String = if self.codeowners_file_path.exists() {
+            std::fs::read_to_string(&self.codeowners_file_path).change_context(Error::Io)?
+        } else {
+            "".to_owned()
+        };
+        Ok(codeowners_file)
     }
 
     pub fn relative_path<'a>(&'a self, absolute_path: &'a Path) -> &'a Path {


### PR DESCRIPTION
## Context
`codeowners validate` and `codeowners-generate-and-validate` both include a validation where it compares the computed CODEOWNERS file to one residing on disk.

## Change
Always validate that the generated file matches the existing file on disk. 

Rather than updating the CODEOWNERS file in memory, read it on demand. the `Project.codeowners_file` is only used during validation.