### PR TITLE
Escaping brackets in team file CODEOWNERS entries

### DIFF
--- a/src/common_test.rs
+++ b/src/common_test.rs
@@ -231,11 +231,20 @@ team_file_glob:
 
         let test_config = TestConfig::new(
             temp_dir.path().to_path_buf(),
-            vec![TestProjectFile {
-                relative_path: "config/teams/baz.yml".to_owned(),
-                content: "name: Baz\ngithub:\n  team: \"@Baz\"\n  members:\n    - Baz member\nowned_globs:\n  - \"packs/bar/**\"\n"
-                    .to_owned(),
-            }],
+            vec![
+                TestProjectFile {
+                    relative_path: "packs/jscomponents/comp.ts".to_owned(),
+                    content: "// @team Foo\n".to_owned(),
+                },
+                TestProjectFile {
+                    relative_path: "packs/[admin]/comp.ts".to_owned(),
+                    content: "// @team Bar\n".to_owned(),
+                },
+                TestProjectFile {
+                    relative_path: "packs/bar/comp.rb".to_owned(),
+                    content: "// @team Bar\n".to_owned(),
+                },
+            ],
         );
         build_ownership(test_config)
     }

--- a/src/ownership/mapper.rs
+++ b/src/ownership/mapper.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 pub(crate) mod directory_mapper;
+mod escaper;
 mod package_mapper;
 mod team_file_mapper;
 mod team_gem_mapper;

--- a/src/ownership/mapper/directory_mapper.rs
+++ b/src/ownership/mapper/directory_mapper.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use super::escaper::escape_brackets;
 use super::{Entry, Source};
 use super::{Mapper, OwnerMatcher};
 use crate::project::Project;
@@ -52,10 +53,6 @@ impl Mapper for DirectoryMapper {
     fn name(&self) -> String {
         "Owner in .codeowner".to_owned()
     }
-}
-
-fn escape_brackets(path: &str) -> String {
-    path.replace("[", "\\[").replace("]", "\\]")
 }
 
 #[cfg(test)]

--- a/src/ownership/mapper/escaper.rs
+++ b/src/ownership/mapper/escaper.rs
@@ -1,0 +1,3 @@
+pub fn escape_brackets(path: &str) -> String {
+    path.replace("[", "\\[").replace("]", "\\]")
+}

--- a/src/ownership/mapper/team_file_mapper.rs
+++ b/src/ownership/mapper/team_file_mapper.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use super::escaper::escape_brackets;
 use super::Entry;
 use super::{Mapper, OwnerMatcher};
 use crate::ownership::mapper::Source;
@@ -30,7 +31,7 @@ impl Mapper for TeamFileMapper {
                     let relative_path = self.project.relative_path(&owned_file.path);
 
                     entries.push(Entry {
-                        path: relative_path.to_string_lossy().to_string(),
+                        path: escape_brackets(&relative_path.to_string_lossy()),
                         github_team: team.github_team.to_owned(),
                         team_name: team.name.to_owned(),
                         disabled: team.avoid_ownership,
@@ -70,16 +71,23 @@ impl Mapper for TeamFileMapper {
 mod tests {
     use std::error::Error;
 
-    use crate::common_test::tests::{build_ownership_with_all_mappers, build_ownership_with_team_file_codeowners, vecs_match};
+    use crate::common_test::tests::{build_ownership_with_team_file_codeowners, vecs_match};
 
     use super::*;
     #[test]
     fn test_entries() -> Result<(), Box<dyn Error>> {
-        let ownership = build_ownership_with_all_mappers()?;
+        let ownership = build_ownership_with_team_file_codeowners()?;
         let mapper = TeamFileMapper::build(ownership.project.clone());
+        dbg!(&mapper.entries());
         vecs_match(
             &mapper.entries(),
             &vec![
+                Entry {
+                    path: "packs/\\[admin\\]/comp.ts".to_owned(),
+                    github_team: "@Bar".to_owned(),
+                    team_name: "Bar".to_owned(),
+                    disabled: false,
+                },
                 Entry {
                     path: "packs/jscomponents/comp.ts".to_owned(),
                     github_team: "@Foo".to_owned(),
@@ -87,9 +95,9 @@ mod tests {
                     disabled: false,
                 },
                 Entry {
-                    path: "packs/zebra/app/services/team_file_owned.rb".to_owned(),
-                    github_team: "@Foo".to_owned(),
-                    team_name: "Foo".to_owned(),
+                    path: "packs/bar/comp.rb".to_owned(),
+                    github_team: "@Bar".to_owned(),
+                    team_name: "Bar".to_owned(),
                     disabled: false,
                 },
             ],
@@ -102,7 +110,14 @@ mod tests {
         let ownership = build_ownership_with_team_file_codeowners()?;
         let mapper = TeamFileMapper::build(ownership.project.clone());
         let owner_matchers = mapper.owner_matchers();
-        let expected_owner_matchers = vec![OwnerMatcher::ExactMatches(HashMap::new(), Source::TeamFile)];
+        let expected_owner_matchers = vec![OwnerMatcher::ExactMatches(
+            HashMap::from([
+                (PathBuf::from("packs/[admin]/comp.ts"), "Bar".to_owned()),
+                (PathBuf::from("packs/bar/comp.rb"), "Bar".to_owned()),
+                (PathBuf::from("packs/jscomponents/comp.ts"), "Foo".to_owned()),
+            ]),
+            Source::TeamFile,
+        )];
         assert_eq!(owner_matchers, expected_owner_matchers);
         Ok(())
     }


### PR DESCRIPTION
Matching https://github.com/rubyatscale/code_ownership/pull/108

The CODEOWNERS entries should include escaped brackets for files with team annotations.