### PR TITLE
Formatting improvements to for_file and validate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "codeowners"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codeowners"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [profile.release]

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,7 +133,7 @@ fn cli() -> Result<(), Error> {
                 _ => {
                     println!("Error: file is owned by multiple teams!");
                     for file_owner in file_owners {
-                        println!("\n{}\n", file_owner);
+                        println!("\n{}", file_owner);
                     }
                 }
             }

--- a/src/ownership.rs
+++ b/src/ownership.rs
@@ -51,13 +51,17 @@ impl TeamOwnership {
 
 impl Display for FileOwner {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let sources = self
-            .sources
-            .iter()
-            .sorted_by_key(|source| source.to_string())
-            .map(|source| source.to_string())
-            .collect::<Vec<String>>()
-            .join("\n- ");
+        let sources = if self.sources.is_empty() {
+            "Unowned".to_string()
+        } else {
+            self.sources
+                .iter()
+                .sorted_by_key(|source| source.to_string())
+                .map(|source| source.to_string())
+                .collect::<Vec<_>>()
+                .join("\n- ")
+        };
+
         write!(
             f,
             "Team: {}\nTeam YML: {}\nDescription:\n- {}",

--- a/src/ownership.rs
+++ b/src/ownership.rs
@@ -1,4 +1,5 @@
 use file_owner_finder::FileOwnerFinder;
+use itertools::Itertools;
 use mapper::{OwnerMatcher, Source, TeamName};
 use std::{
     error::Error,
@@ -53,12 +54,13 @@ impl Display for FileOwner {
         let sources = self
             .sources
             .iter()
+            .sorted_by_key(|source| source.to_string())
             .map(|source| source.to_string())
             .collect::<Vec<String>>()
-            .join(", ");
+            .join("\n- ");
         write!(
             f,
-            "Team: {}\nTeam YML: {}\nDescription: {}",
+            "Team: {}\nTeam YML: {}\nDescription:\n- {}",
             self.team_name, self.team_config_file_path, sources
         )
     }
@@ -123,6 +125,7 @@ impl Ownership {
         let owners = file_owner_finder.find(Path::new(file_path));
         Ok(owners
             .iter()
+            .sorted_by_key(|owner| owner.team_name.to_lowercase())
             .map(|owner| match self.project.get_team(&owner.team_name) {
                 Some(team) => FileOwner {
                     team_name: owner.team_name.clone(),

--- a/src/ownership/validator.rs
+++ b/src/ownership/validator.rs
@@ -173,16 +173,16 @@ impl Error {
     pub fn messages(&self) -> Vec<String> {
         match self {
             Error::FileWithoutOwner { path } => vec![format!("- {}", path.to_string_lossy())],
-            Error::FileWithMultipleOwners { path, owners } => owners
-                .iter()
-                .flat_map(|owner| {
-                    owner
-                        .sources
-                        .iter()
-                        .map(|source| format!("- {} (owner: {}, source: {})", path.to_string_lossy(), owner.team_name, &source))
-                        .collect_vec()
-                })
-                .collect_vec(),
+            Error::FileWithMultipleOwners { path, owners } => {
+                let mut output = vec![format!("\n{}", path.to_string_lossy().to_string())];
+                for owner in owners.iter().sorted_by_key(|owner| owner.team_name.to_lowercase()) {
+                    output.push(format!(" owner: {}", owner.team_name));
+                    for source in &owner.sources {
+                        output.push(format!("  - {}", source));
+                    }
+                }
+                vec![output.join("\n")]
+            }
             Error::CodeownershipFileIsStale => vec![],
             Error::InvalidTeam { name, path } => vec![format!("- {} is referencing an invalid team - '{}'", path.to_string_lossy(), name)],
         }

--- a/src/ownership/validator.rs
+++ b/src/ownership/validator.rs
@@ -174,14 +174,18 @@ impl Error {
         match self {
             Error::FileWithoutOwner { path } => vec![format!("- {}", path.to_string_lossy())],
             Error::FileWithMultipleOwners { path, owners } => {
-                let mut output = vec![format!("\n{}", path.to_string_lossy().to_string())];
-                for owner in owners.iter().sorted_by_key(|owner| owner.team_name.to_lowercase()) {
-                    output.push(format!(" owner: {}", owner.team_name));
-                    for source in &owner.sources {
-                        output.push(format!("  - {}", source));
-                    }
-                }
-                vec![output.join("\n")]
+                let path_display = path.to_string_lossy();
+                let mut messages = vec![format!("\n{path_display}")];
+
+                owners
+                    .iter()
+                    .sorted_by_key(|owner| owner.team_name.to_lowercase())
+                    .for_each(|owner| {
+                        messages.push(format!(" owner: {}", owner.team_name));
+                        messages.extend(owner.sources.iter().map(|source| format!("  - {source}")));
+                    });
+
+                vec![messages.join("\n")]
             }
             Error::CodeownershipFileIsStale => vec![],
             Error::InvalidTeam { name, path } => vec![format!("- {} is referencing an invalid team - '{}'", path.to_string_lossy(), name)],

--- a/tests/invalid_project_test.rs
+++ b/tests/invalid_project_test.rs
@@ -79,4 +79,4 @@ fn test_for_file_multiple_owners() -> Result<(), Box<dyn Error>> {
             - Owner specified in `ruby/app/services/.codeowner`
         "}));
     Ok(())
-}          
+}

--- a/tests/invalid_project_test.rs
+++ b/tests/invalid_project_test.rs
@@ -16,10 +16,18 @@ fn test_validate() -> Result<(), Box<dyn Error>> {
             CODEOWNERS out of date. Run `codeowners generate` to update the CODEOWNERS file
 
             Code ownership should only be defined for each file in one way. The following files have declared ownership in multiple ways
-            - gems/payroll_calculator/calculator.rb (owner: Payments, source: Owner annotation at the top of the file)
-            - gems/payroll_calculator/calculator.rb (owner: Payroll, source: Owner specified in Team YML's `owned_gems`)
-            - ruby/app/services/multi_owned.rb (owner: Payments, source: Owner annotation at the top of the file)
-            - ruby/app/services/multi_owned.rb (owner: Payroll, source: Owner specified in `ruby/app/services/.codeowner`)
+
+            gems/payroll_calculator/calculator.rb
+             owner: Payments
+              - Owner annotation at the top of the file
+             owner: Payroll
+              - Owner specified in Team YML's `owned_gems`
+
+            ruby/app/services/multi_owned.rb
+             owner: Payments
+              - Owner annotation at the top of the file
+             owner: Payroll
+              - Owner specified in `ruby/app/services/.codeowner`
 
             Found invalid team annotations
             - ruby/app/models/blockchain.rb is referencing an invalid team - 'Web3'

--- a/tests/invalid_project_test.rs
+++ b/tests/invalid_project_test.rs
@@ -52,7 +52,7 @@ fn test_for_file() -> Result<(), Box<dyn Error>> {
         .stdout(predicate::eq(indoc! {"
             Team: Unowned
             Team YML: Unowned
-            Description: \n"})); // trailing whitespace
+            Description:\n- \n"})); // trailing whitespace
     Ok(())
 }
 
@@ -65,17 +65,18 @@ fn test_for_file_multiple_owners() -> Result<(), Box<dyn Error>> {
         .arg("ruby/app/services/multi_owned.rb")
         .assert()
         .success()
-        .stdout(predicate::str::starts_with("Error: file is owned by multiple teams!"))
-        // order not static
-        .stdout(predicate::str::contains(indoc! {"
-            Team: Payroll
-            Team YML: config/teams/payroll.yml
-            Description: Owner specified in `ruby/app/services/.codeowner`
-        "}))
-        .stdout(predicate::str::contains(indoc! {"
+        .stdout(predicate::eq(indoc! {"
+            Error: file is owned by multiple teams!
+
             Team: Payments
             Team YML: config/teams/payments.yml
-            Description: Owner annotation at the top of the file
+            Description:
+            - Owner annotation at the top of the file
+
+            Team: Payroll
+            Team YML: config/teams/payroll.yml
+            Description:
+            - Owner specified in `ruby/app/services/.codeowner`
         "}));
     Ok(())
-}
+}          

--- a/tests/invalid_project_test.rs
+++ b/tests/invalid_project_test.rs
@@ -52,7 +52,9 @@ fn test_for_file() -> Result<(), Box<dyn Error>> {
         .stdout(predicate::eq(indoc! {"
             Team: Unowned
             Team YML: Unowned
-            Description:\n- \n"})); // trailing whitespace
+            Description:
+            - Unowned
+            "}));
     Ok(())
 }
 

--- a/tests/valid_project_test.rs
+++ b/tests/valid_project_test.rs
@@ -46,7 +46,8 @@ fn test_for_file() -> Result<(), Box<dyn Error>> {
         .stdout(predicate::eq(indoc! {"
             Team: Payroll
             Team YML: config/teams/payroll.yml
-            Description: Owner annotation at the top of the file
+            Description:
+            - Owner annotation at the top of the file
         "}));
     Ok(())
 }

--- a/tests/valid_project_test.rs
+++ b/tests/valid_project_test.rs
@@ -54,14 +54,6 @@ fn test_for_file() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_for_file_same_team_multiple_ownerships() -> Result<(), Box<dyn Error>> {
-    let expected_output = r#"
-Team: Payroll
-Team YML: config/teams/payroll.yml
-Description:
-- Owner annotation at the top of the file
-- Owner defined in `javascript/packages/PayrollFlow/package.json` with implicity owned glob: `javascript/packages/PayrollFlow/**/**`
-    "#
-    .trim();
     Command::cargo_bin("codeowners")?
         .arg("--project-root")
         .arg("tests/fixtures/valid_project")
@@ -69,7 +61,13 @@ Description:
         .arg("javascript/packages/PayrollFlow/index.tsx")
         .assert()
         .success()
-        .stdout(predicate::str::contains(expected_output));
+        .stdout(predicate::eq(indoc! {"
+            Team: Payroll
+            Team YML: config/teams/payroll.yml
+            Description:
+            - Owner annotation at the top of the file
+            - Owner defined in `javascript/packages/PayrollFlow/package.json` with implicity owned glob: `javascript/packages/PayrollFlow/**/**`
+        "}));
     Ok(())
 }
 
@@ -82,8 +80,13 @@ fn test_for_file_with_2_ownerships() -> Result<(), Box<dyn Error>> {
         .arg("javascript/packages/PayrollFlow/index.tsx")
         .assert()
         .success()
-        .stdout(predicate::str::contains("Team: Payroll"))
-        .stdout(predicate::str::contains("Team YML: config/teams/payroll.yml"));
+        .stdout(predicate::eq(indoc! {"
+            Team: Payroll
+            Team YML: config/teams/payroll.yml
+            Description:
+            - Owner annotation at the top of the file
+            - Owner defined in `javascript/packages/PayrollFlow/package.json` with implicity owned glob: `javascript/packages/PayrollFlow/**/**`
+        "}));
 
     Ok(())
 }

--- a/tests/valid_project_test.rs
+++ b/tests/valid_project_test.rs
@@ -52,6 +52,21 @@ fn test_for_file() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+fn test_for_file_with_2_ownerships() -> Result<(), Box<dyn Error>> {
+    Command::cargo_bin("codeowners")?
+        .arg("--project-root")
+        .arg("tests/fixtures/valid_project")
+        .arg("for-file")
+        .arg("javascript/packages/PayrollFlow/index.tsx")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Team: Payroll"))
+        .stdout(predicate::str::contains("Team YML: config/teams/payroll.yml"));
+
+    Ok(())
+}
+
+#[test]
 fn test_for_team() -> Result<(), Box<dyn Error>> {
     Command::cargo_bin("codeowners")?
         .arg("--project-root")

--- a/tests/valid_project_test.rs
+++ b/tests/valid_project_test.rs
@@ -52,6 +52,27 @@ fn test_for_file() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+fn test_for_file_same_team_multiple_ownerships() -> Result<(), Box<dyn Error>> {
+    let expected_output = r#"
+Team: Payroll
+Team YML: config/teams/payroll.yml
+Description:
+- Owner annotation at the top of the file
+- Owner defined in `javascript/packages/PayrollFlow/package.json` with implicity owned glob: `javascript/packages/PayrollFlow/**/**`
+    "#
+    .trim();
+    Command::cargo_bin("codeowners")?
+        .arg("--project-root")
+        .arg("tests/fixtures/valid_project")
+        .arg("for-file")
+        .arg("javascript/packages/PayrollFlow/index.tsx")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(expected_output));
+    Ok(())
+}
+
+#[test]
 fn test_for_file_with_2_ownerships() -> Result<(), Box<dyn Error>> {
     Command::cargo_bin("codeowners")?
         .arg("--project-root")


### PR DESCRIPTION
for-file
```bash
Error: file is owned by multiple teams!

Team: Payments
Team YML: config/teams/payments.yml
Description:
- Owner annotation at the top of the file

Team: Payroll
Team YML: config/teams/payroll.yml
Description:
- Owner specified in `ruby/app/services/.codeowner`
```

Validate
```bash
Code ownership should only be defined for each file in one way. The following files have declared ownership in multiple ways

packs/product_services/payroll_canada/async_api/app/services/payroll_canada_async_api/message_handler.rb
 owner: Benefits Foundation
  - Owner annotation at the top of the file
 owner: Payroll Canada
  - Owner defined in `packs/product_services/payroll_canada/async_api/package.yml` with implicity owned glob: `packs/product_services/payroll_canada/async_api/**/**`
  ```