### PR TITLE
Adding github team to for-file results

### DIFF
--- a/src/project.rs
+++ b/src/project.rs
@@ -29,7 +29,7 @@ pub struct ProjectFile {
     pub path: PathBuf,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Team {
     pub path: PathBuf,
     pub name: String,

--- a/tests/invalid_project_test.rs
+++ b/tests/invalid_project_test.rs
@@ -53,7 +53,8 @@ fn test_for_file() -> Result<(), Box<dyn Error>> {
         .success()
         .stdout(predicate::eq(indoc! {"
             Team: Unowned
-            Team YML: Unowned
+            Github Team: Unowned
+            Team YML: 
             Description:
             - Unowned
             "}));
@@ -72,13 +73,15 @@ fn test_for_file_multiple_owners() -> Result<(), Box<dyn Error>> {
         .success()
         .stdout(predicate::eq(indoc! {"
             Error: file is owned by multiple teams!
-
+            
             Team: Payments
+            Github Team: @PaymentTeam
             Team YML: config/teams/payments.yml
             Description:
             - Owner annotation at the top of the file
-
+            
             Team: Payroll
+            Github Team: @PayrollTeam
             Team YML: config/teams/payroll.yml
             Description:
             - Owner specified in `ruby/app/services/.codeowner`

--- a/tests/valid_project_test.rs
+++ b/tests/valid_project_test.rs
@@ -48,6 +48,7 @@ fn test_for_file() -> Result<(), Box<dyn Error>> {
         .success()
         .stdout(predicate::eq(indoc! {"
             Team: Payroll
+            Github Team: @PayrollTeam
             Team YML: config/teams/payroll.yml
             Description:
             - Owner annotation at the top of the file
@@ -67,6 +68,7 @@ fn test_for_file_same_team_multiple_ownerships() -> Result<(), Box<dyn Error>> {
         .success()
         .stdout(predicate::eq(indoc! {"
             Team: Payroll
+            Github Team: @PayrollTeam
             Team YML: config/teams/payroll.yml
             Description:
             - Owner annotation at the top of the file
@@ -87,6 +89,7 @@ fn test_for_file_with_2_ownerships() -> Result<(), Box<dyn Error>> {
         .success()
         .stdout(predicate::eq(indoc! {"
             Team: Payroll
+            Github Team: @PayrollTeam
             Team YML: config/teams/payroll.yml
             Description:
             - Owner annotation at the top of the file


### PR DESCRIPTION
![out](https://github.com/user-attachments/assets/9424703d-4534-46d4-8556-2450ef2e8d00)

Adds a `Github Team` line to `for-file` results
