### PR TITLE
Add support for --json to match ruby codeownership cli

### DIFF
--- a/src/project.rs
+++ b/src/project.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use error_stack::{Context, Result, ResultExt};
+use serde::Serialize;
 
 pub struct Project {
     pub base_path: PathBuf,
@@ -29,7 +30,7 @@ pub struct ProjectFile {
     pub path: PathBuf,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Serialize)]
 pub struct Team {
     pub path: PathBuf,
     pub name: String,


### PR DESCRIPTION
Currently, https://github.com/rubyatscale/code-ownership-vscode uses `bin/codeownership` to check the ownership to display. I was making some other changes, and thought maybe we could be using `--json`. We don't have that yet.

As an aside, it seems like that looking up a single `for-file` is about the same as `gv`, which is interesting. I was thinking about if there's an opportunity to make this an LSP? Or maybe just a long lived client/server so there isn't up front lookup cost.