### PR TITLE
Simplifying file_owner_for_file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "codeowners"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codeowners"
-version = "0.2.13"
+version = "0.2.14"
 edition = "2024"
 
 [profile.release]

--- a/src/ownership.rs
+++ b/src/ownership.rs
@@ -33,7 +33,7 @@ use self::{
 pub struct Ownership {
     project: Arc<Project>,
 }
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FileOwner {
     pub team: Team,
     pub team_config_file_path: String,


### PR DESCRIPTION
When working on the [code_ownership](https://github.com/rubyatscale/code_ownership) gem, I decided that passing on the complexity of multiple file owners from different teams was unnecessary.
