### PR TITLE
Accept files for validation to speed up validation process

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,12 +38,17 @@ enum Command {
         about = "Validate the validity of the CODEOWNERS file. A validation failure will exit with a failure code and a detailed output of the validation errors.",
         visible_alias = "v"
     )]
-    Validate,
+    Validate {
+        #[arg(help = "Optional list of files to validate ownership for (fast mode for git hooks)")]
+        files: Vec<String>,
+    },
 
     #[clap(about = "Chains both `generate` and `validate` commands.", visible_alias = "gv")]
     GenerateAndValidate {
         #[arg(long, short, default_value = "false", help = "Skip staging the CODEOWNERS file")]
         skip_stage: bool,
+        #[arg(help = "Optional list of files to validate ownership for (fast mode for git hooks)")]
+        files: Vec<String>,
     },
 
     #[clap(about = "Delete the cache file.", visible_alias = "d")]
@@ -112,9 +117,9 @@ pub fn cli() -> Result<RunResult, RunnerError> {
     };
 
     let runner_result = match args.command {
-        Command::Validate => runner::validate(&run_config, vec![]),
+        Command::Validate { files } => runner::validate(&run_config, files),
         Command::Generate { skip_stage } => runner::generate(&run_config, !skip_stage),
-        Command::GenerateAndValidate { skip_stage } => runner::generate_and_validate(&run_config, vec![], !skip_stage),
+        Command::GenerateAndValidate { files, skip_stage } => runner::generate_and_validate(&run_config, files, !skip_stage),
         Command::ForFile {
             name,
             from_codeowners,

--- a/src/runner/api.rs
+++ b/src/runner/api.rs
@@ -16,16 +16,16 @@ pub fn for_team(run_config: &RunConfig, team_name: &str) -> RunResult {
     run(run_config, |runner| runner.for_team(team_name))
 }
 
-pub fn validate(run_config: &RunConfig, _file_paths: Vec<String>) -> RunResult {
-    run(run_config, |runner| runner.validate())
+pub fn validate(run_config: &RunConfig, file_paths: Vec<String>) -> RunResult {
+    run(run_config, |runner| runner.validate(file_paths))
 }
 
 pub fn generate(run_config: &RunConfig, git_stage: bool) -> RunResult {
     run(run_config, |runner| runner.generate(git_stage))
 }
 
-pub fn generate_and_validate(run_config: &RunConfig, _file_paths: Vec<String>, git_stage: bool) -> RunResult {
-    run(run_config, |runner| runner.generate_and_validate(git_stage))
+pub fn generate_and_validate(run_config: &RunConfig, file_paths: Vec<String>, git_stage: bool) -> RunResult {
+    run(run_config, |runner| runner.generate_and_validate(file_paths, git_stage))
 }
 
 pub fn delete_cache(run_config: &RunConfig) -> RunResult {

--- a/tests/validate_files_test.rs
+++ b/tests/validate_files_test.rs
@@ -1,0 +1,144 @@
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+use std::{error::Error, process::Command};
+
+mod common;
+
+use common::*;
+
+#[test]
+fn test_validate_with_owned_files() -> Result<(), Box<dyn Error>> {
+    run_codeowners(
+        "valid_project",
+        &["validate", "ruby/app/models/payroll.rb", "ruby/app/models/bank_account.rb"],
+        true,
+        OutputStream::Stdout,
+        predicate::eq(""),
+    )?;
+
+    Ok(())
+}
+
+#[test]
+fn test_validate_with_unowned_file() -> Result<(), Box<dyn Error>> {
+    run_codeowners(
+        "valid_project",
+        &["validate", "ruby/app/unowned.rb"],
+        false,
+        OutputStream::Stdout,
+        predicate::str::contains("ruby/app/unowned.rb").and(predicate::str::contains("Unowned")),
+    )?;
+
+    Ok(())
+}
+
+#[test]
+fn test_validate_with_mixed_files() -> Result<(), Box<dyn Error>> {
+    run_codeowners(
+        "valid_project",
+        &["validate", "ruby/app/models/payroll.rb", "ruby/app/unowned.rb"],
+        false,
+        OutputStream::Stdout,
+        predicate::str::contains("ruby/app/unowned.rb").and(predicate::str::contains("Unowned")),
+    )?;
+
+    Ok(())
+}
+
+#[test]
+fn test_validate_with_no_files() -> Result<(), Box<dyn Error>> {
+    // Existing behavior - validates entire project
+    run_codeowners("valid_project", &["validate"], true, OutputStream::Stdout, predicate::eq(""))?;
+
+    Ok(())
+}
+
+#[test]
+fn test_generate_and_validate_with_owned_files() -> Result<(), Box<dyn Error>> {
+    let fixture_root = std::path::Path::new("tests/fixtures/valid_project");
+    let temp_dir = setup_fixture_repo(fixture_root);
+    let project_root = temp_dir.path();
+    git_add_all_files(project_root);
+
+    let codeowners_path = project_root.join("tmp/CODEOWNERS");
+
+    Command::cargo_bin("codeowners")?
+        .arg("--project-root")
+        .arg(project_root)
+        .arg("--codeowners-file-path")
+        .arg(&codeowners_path)
+        .arg("--no-cache")
+        .arg("generate-and-validate")
+        .arg("ruby/app/models/payroll.rb")
+        .arg("ruby/app/models/bank_account.rb")
+        .assert()
+        .success();
+
+    Ok(())
+}
+
+#[test]
+fn test_generate_and_validate_with_unowned_file() -> Result<(), Box<dyn Error>> {
+    let fixture_root = std::path::Path::new("tests/fixtures/valid_project");
+    let temp_dir = setup_fixture_repo(fixture_root);
+    let project_root = temp_dir.path();
+    git_add_all_files(project_root);
+
+    let codeowners_path = project_root.join("tmp/CODEOWNERS");
+
+    Command::cargo_bin("codeowners")?
+        .arg("--project-root")
+        .arg(project_root)
+        .arg("--codeowners-file-path")
+        .arg(&codeowners_path)
+        .arg("--no-cache")
+        .arg("generate-and-validate")
+        .arg("ruby/app/unowned.rb")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("ruby/app/unowned.rb"))
+        .stdout(predicate::str::contains("Unowned"));
+
+    Ok(())
+}
+
+#[test]
+fn test_validate_with_absolute_path() -> Result<(), Box<dyn Error>> {
+    let fixture_root = std::path::Path::new("tests/fixtures/valid_project");
+    let temp_dir = setup_fixture_repo(fixture_root);
+    let project_root = temp_dir.path();
+    git_add_all_files(project_root);
+
+    let file_absolute_path = project_root.join("ruby/app/models/payroll.rb").canonicalize()?;
+
+    Command::cargo_bin("codeowners")?
+        .arg("--project-root")
+        .arg(project_root)
+        .arg("--no-cache")
+        .arg("validate")
+        .arg(file_absolute_path.to_str().unwrap())
+        .assert()
+        .success();
+
+    Ok(())
+}
+
+#[test]
+fn test_validate_only_checks_codeowners_file() -> Result<(), Box<dyn Error>> {
+    // This test demonstrates that `validate` with files only checks the CODEOWNERS file
+    // It does NOT check file annotations or other ownership sources
+    //
+    // If a file has an annotation but is missing from CODEOWNERS, `validate` will report it as unowned
+    // This is why `generate-and-validate` should be used for accuracy
+
+    // ruby/app/models/bank_account.rb has @team Payments annotation and is in CODEOWNERS
+    run_codeowners(
+        "valid_project",
+        &["validate", "ruby/app/models/bank_account.rb"],
+        true,
+        OutputStream::Stdout,
+        predicate::eq(""),
+    )?;
+
+    Ok(())
+}


### PR DESCRIPTION
this performs a check on changed files passed to the command line, allowing a much faster check during pre-commit hooks.

the recommended usage would be the `gv` subcommand which will generate and then check only the files passed, ensuring that the codeowners file is correct such that the validation is correct.