### PR TITLE
Fix regression in package.yml metadata.owner key

### DIFF
--- a/src/project.rs
+++ b/src/project.rs
@@ -112,6 +112,7 @@ pub mod deserializers {
     #[derive(Deserialize)]
     pub struct RubyPackage {
         pub owner: Option<String>,
+        pub metadata: Option<Metadata>,
     }
 
     #[derive(Deserialize)]


### PR DESCRIPTION
As far as I can tell, this key was not intentionally removed and its presence is missed. Based on issues reported, We're restoring support rather than fix all the other things that depend on it.

Related to: rubyatscale/code_ownership#141