### PR TITLE
Change executable_name to hold the full command string

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,15 +18,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - name: Run cargo check
-        run: cargo check
   test:
     name: Test Suite
     runs-on: ubuntu-latest
@@ -58,7 +49,6 @@ jobs:
     needs:
       - test
       - lints
-      - check
     outputs:
       new_version: ${{ steps.check_for_version_changes.outputs.new_version }}
       changed: ${{ steps.check_for_version_changes.outputs.changed }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,15 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Run cargo check
+        run: cargo check
   test:
     name: Test Suite
     runs-on: ubuntu-latest
@@ -49,6 +58,7 @@ jobs:
     needs:
       - test
       - lints
+      - check
     outputs:
       new_version: ${{ steps.check_for_version_changes.outputs.new_version }}
       changed: ${{ steps.check_for_version_changes.outputs.changed }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,31 +18,12 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - name: Cache Rust build artifacts
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: false
-
-      - name: Run cargo check
-        run: cargo check
   test:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-
-      - name: Cache Rust build artifacts
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: false
 
       - name: Run cargo test with backtrace
         run: cargo test -- --nocapture
@@ -57,11 +38,6 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
-      - name: Cache Rust build artifacts
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: false
-
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
 
@@ -71,7 +47,6 @@ jobs:
   release:
     runs-on: macos-latest
     needs:
-      - check
       - test
       - lints
     outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,31 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: false
+
+      - name: Run cargo check
+        run: cargo check
   test:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: false
 
       - name: Run cargo test with backtrace
         run: cargo test -- --nocapture
@@ -38,6 +57,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: false
+
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
 
@@ -47,6 +71,7 @@ jobs:
   release:
     runs-on: macos-latest
     needs:
+      - check
       - test
       - lints
     outputs:

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,7 +68,7 @@ fn vendored_gems_path() -> String {
 }
 
 fn default_executable_name() -> String {
-    "codeowners".to_string()
+    "codeowners generate".to_string()
 }
 
 fn default_ignore_dirs() -> Vec<String> {
@@ -134,7 +134,7 @@ mod tests {
             vec!["frontend/**/node_modules/**/*", "frontend/**/__generated__/**/*"]
         );
         assert_eq!(config.vendored_gems_path, "vendored/");
-        assert_eq!(config.executable_name, "codeowners");
+        assert_eq!(config.executable_name, "codeowners generate");
         Ok(())
     }
 
@@ -167,7 +167,7 @@ mod tests {
         fs::write(&config_path, config_str)?;
         let config_file = File::open(&config_path)?;
         let config: Config = serde_yaml::from_reader(config_file)?;
-        assert_eq!(config.executable_name, "codeowners");
+        assert_eq!(config.executable_name, "codeowners generate");
         Ok(())
     }
 

--- a/src/ownership/validator.rs
+++ b/src/ownership/validator.rs
@@ -169,7 +169,7 @@ impl Error {
                 Error::FileWithoutOwner { path: _ } => "Some files are missing ownership".to_owned(),
                 Error::FileWithMultipleOwners { path: _, owners: _ } => "Code ownership should only be defined for each file in one way. The following files have declared ownership in multiple ways".to_owned(),
                 Error::CodeownershipFileIsStale { executable_name } => {
-                    format!("CODEOWNERS out of date. Run `{} generate` to update the CODEOWNERS file", executable_name)
+                    format!("CODEOWNERS out of date. Run `{}` to update the CODEOWNERS file", executable_name)
                 }
                 Error::InvalidTeam { name: _, path: _ } => "Found invalid team annotations".to_owned(),
             }

--- a/src/project.rs
+++ b/src/project.rs
@@ -221,7 +221,7 @@ mod tests {
             codeowners_file_path: PathBuf::from(".github/CODEOWNERS"),
             directory_codeowner_files: vec![],
             teams_by_name: HashMap::new(),
-            executable_name: "codeowners".to_string(),
+            executable_name: "codeowners generate".to_string(),
         };
 
         let map = project.vendored_gem_by_name();

--- a/tests/executable_name_config_test.rs
+++ b/tests/executable_name_config_test.rs
@@ -14,7 +14,7 @@ fn test_validate_with_custom_executable_name() -> Result<(), Box<dyn Error>> {
         &["validate"],
         false,
         OutputStream::Stdout,
-        predicate::str::contains("Run `bin/codeownership generate`"),
+        predicate::str::contains("Run `bin/codeownership validate`"),
     )?;
     Ok(())
 }
@@ -42,7 +42,7 @@ fn test_custom_executable_name_full_error_message() -> Result<(), Box<dyn Error>
         OutputStream::Stdout,
         predicate::eq(indoc! {"
 
-    CODEOWNERS out of date. Run `bin/codeownership generate` to update the CODEOWNERS file
+    CODEOWNERS out of date. Run `bin/codeownership validate` to update the CODEOWNERS file
 
     "}),
     )?;

--- a/tests/fixtures/custom_executable_name/config/code_ownership.yml
+++ b/tests/fixtures/custom_executable_name/config/code_ownership.yml
@@ -1,4 +1,4 @@
 ---
 owned_globs:
   - "{app,config}/**/*.rb"
-executable_name: "bin/codeownership"
+executable_name: "bin/codeownership validate"

--- a/tests/run_config_executable_override_test.rs
+++ b/tests/run_config_executable_override_test.rs
@@ -13,21 +13,20 @@ fn test_run_config_executable_path_overrides_config_file() -> Result<(), Box<dyn
     let project_path = temp_dir.path();
     git_add_all_files(project_path);
 
-    // This fixture has executable_name: "bin/codeownership" in config
-    // But we'll override it with RunConfig.executable_path
+    // This fixture has executable_name: "bin/codeownership validate" in config
+    // But we'll override it with RunConfig.executable_name
 
     let mut run_config = build_run_config(project_path, ".github/CODEOWNERS");
-    // Use a relative path that gets displayed as-is in error messages
-    run_config.executable_name = Some("my-wrapper-tool".to_string());
+    run_config.executable_name = Some("my-wrapper-tool validate".to_string());
 
     let result = validate(&run_config, vec![]);
 
-    // Should use "my-wrapper-tool" from executable_path, NOT "bin/codeownership" from config
+    // Should use "my-wrapper-tool validate" from RunConfig, NOT "bin/codeownership validate" from config
     assert!(!result.validation_errors.is_empty(), "Expected validation errors but got none");
     let error_msg = result.validation_errors.join("\n");
     assert!(
-        error_msg.contains("Run `my-wrapper-tool generate`"),
-        "Expected error to contain 'my-wrapper-tool generate' but got: {}",
+        error_msg.contains("Run `my-wrapper-tool validate`"),
+        "Expected error to contain 'my-wrapper-tool validate' but got: {}",
         error_msg
     );
     assert!(
@@ -47,19 +46,19 @@ fn test_run_config_without_executable_path_uses_config_file() -> Result<(), Box<
     let project_path = temp_dir.path();
     git_add_all_files(project_path);
 
-    // This fixture has executable_name: "bin/codeownership" in config
+    // This fixture has executable_name: "bin/codeownership validate" in config
 
     let mut run_config = build_run_config(project_path, ".github/CODEOWNERS");
     run_config.executable_name = None; // Explicitly no override
 
     let result = validate(&run_config, vec![]);
 
-    // Should use "bin/codeownership" from config file
+    // Should use "bin/codeownership validate" from config file
     assert!(!result.validation_errors.is_empty(), "Expected validation errors but got none");
     let error_msg = result.validation_errors.join("\n");
     assert!(
-        error_msg.contains("Run `bin/codeownership generate`"),
-        "Expected error to contain 'bin/codeownership generate' but got: {}",
+        error_msg.contains("Run `bin/codeownership validate`"),
+        "Expected error to contain 'bin/codeownership validate' but got: {}",
         error_msg
     );
 
@@ -75,14 +74,14 @@ fn test_run_config_executable_path_overrides_default() -> Result<(), Box<dyn Err
     let project_path = temp_dir.path();
     git_add_all_files(project_path);
 
-    // This fixture has NO executable_name in config (uses default "codeowners")
+    // This fixture has NO executable_name in config (uses default "codeowners generate")
 
     let mut run_config = build_run_config(project_path, ".github/CODEOWNERS");
-    run_config.executable_name = Some("custom-command".to_string());
+    run_config.executable_name = Some("custom-command generate".to_string());
 
     let result = validate(&run_config, vec![]);
 
-    // Should use "custom-command" from executable_path, NOT default "codeowners"
+    // Should use "custom-command generate" from RunConfig, NOT default "codeowners generate"
     assert!(!result.validation_errors.is_empty(), "Expected validation errors but got none");
     let error_msg = result.validation_errors.join("\n");
     assert!(


### PR DESCRIPTION
## Summary

- The `executable_name` field was used as just the binary name, with ` generate` hardcoded as the subcommand in the error message format string. This made it impossible for wrappers to specify the correct update command when their subcommand isn't `generate`.
- `executable_name` now holds the **full command** to run (e.g. `"codeowners generate"`, `"bin/codeownership validate"`). The ` generate` suffix is removed from the format string.
- The default changes from `"codeowners"` → `"codeowners generate"` so all existing behavior is preserved for users who do not customize the field.

**Migration for custom `executable_name` in config:**
```yaml
# Before
executable_name: my-tool

# After
executable_name: my-tool generate
```

This is a companion change to https://github.com/rubyatscale/code_ownership/pull/164, which fixes the misleading error message users of the Ruby gem see (rubyatscale/code_ownership#155).

## Test plan

- [ ] All existing tests pass (`cargo test`)
- [ ] Pre-commit hook runs `cargo clippy`, `cargo test`, and `cargo fmt --check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)