### PR TITLE
Fix tracked file paths for subdirectories

### DIFF
--- a/src/tracked_files.rs
+++ b/src/tracked_files.rs
@@ -6,7 +6,7 @@ use std::{
 
 pub(crate) fn find_tracked_files(base_path: &Path) -> Option<HashMap<PathBuf, bool>> {
     let output = Command::new("git")
-        .args(["ls-files", "--full-name", "-z", "--", "."])
+        .args(["ls-files", "-z", "--", "."])
         .current_dir(base_path)
         .output()
         .ok()?;
@@ -54,5 +54,33 @@ mod tests {
         let tracked = find_tracked_files(tmp_dir.path()).unwrap();
         assert!(tracked.len() == 1);
         assert!(tracked.get(&tmp_dir.path().join("test.txt")).unwrap());
+    }
+
+    #[test]
+    fn test_tracked_files_from_subdirectory() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let backend_dir = tmp_dir.path().join("backend");
+        let tracked_file = backend_dir.join("app/models/foo.rb");
+
+        std::process::Command::new("git")
+            .arg("init")
+            .current_dir(tmp_dir.path())
+            .output()
+            .expect("failed to run git init");
+
+        std::fs::create_dir_all(tracked_file.parent().unwrap()).unwrap();
+        std::fs::write(&tracked_file, "class Foo; end").unwrap();
+        std::fs::write(tmp_dir.path().join("README.md"), "readme").unwrap();
+
+        std::process::Command::new("git")
+            .args(["add", "--all"])
+            .current_dir(tmp_dir.path())
+            .output()
+            .expect("failed to add tracked files");
+
+        let tracked = find_tracked_files(&backend_dir).unwrap();
+        assert_eq!(tracked.len(), 1);
+        assert!(tracked.get(&tracked_file).unwrap());
+        assert!(!tracked.contains_key(&backend_dir.join("backend/app/models/foo.rb")));
     }
 }


### PR DESCRIPTION
## Summary
- remove `--full-name` from `git ls-files` so tracked paths stay relative to the supplied `base_path`
- add a regression test covering `find_tracked_files` when called from a subdirectory inside a git repo

## Root cause
`git ls-files --full-name` always emits paths relative to the repository root. `find_tracked_files` then joined those repo-root-relative paths onto `base_path`, which doubled nested prefixes like `/repo/backend/backend/...` when the caller ran from a subdirectory.

## Validation
- `cargo test tracked_files -- --nocapture`
- `cargo test`
- `cargo fmt --check`
