### PR TITLE
Bump version to 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "codeowners"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codeowners"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 
 [profile.release]


### PR DESCRIPTION
## Summary

Patch version bump from 0.3.1 to 0.3.2 for the next release.

## What's in 0.3.2

- Allow to specify CODEOWNERS location in config or env var (#95)
- Fix validate to respect owned_globs when files specified
- Fix regression in package.yml metadata.owner key (#85)
- Fix missing Path import lost during merge of #89 (#100)
- Fix tracked file paths for subdirectories (#103)
- Change executable_name to hold the full command string (#101)

🤖 Generated with [Claude Code](https://claude.com/claude-code)