### PR TITLE
Bump version to 0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "codeowners"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codeowners"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 
 [profile.release]


### PR DESCRIPTION
Bumps the version to 0.3.3 to release the `compare_lines` total-order fix (#105/#106), which landed on `main` after the 0.3.2 tag and is not yet in any published release.

That fix makes the CODEOWNERS sort order deterministic across platforms. Before it, the comparator was not a valid total order, so `Vec::sort_by` could produce different orderings depending on input order — which surfaces as a different generated `.github/CODEOWNERS` on macOS arm64 vs Linux x86_64, breaking "CODEOWNERS out of date" validation.

## Changes
- `Cargo.toml` / `Cargo.lock`: `0.3.2` → `0.3.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)